### PR TITLE
Rename `Post.owner` Property To `Post.sender` To Match The Assignment Specification

### DIFF
--- a/controllers/posts_controller.js
+++ b/controllers/posts_controller.js
@@ -1,10 +1,10 @@
 const postModel = require('../models/posts_model');
 
 const getAllPosts =  async (req, res) => {
-    const ownerFilter = req.query.owner;
+    const senderFilter = req.query.sender;
     try{
-        if(ownerFilter){
-            const posts = await postModel.find({owner: ownerFilter});
+        if(senderFilter){
+            const posts = await postModel.find({sender: senderFilter});
             res.status(200).send(posts);
             
         } else{

--- a/models/posts_model.js
+++ b/models/posts_model.js
@@ -8,7 +8,7 @@ const postSchema = new Schema({
         required: true
     },
     content: String,
-    owner: {
+    sender: {
         type: String,
         required: true
     },

--- a/request.rest
+++ b/request.rest
@@ -5,7 +5,7 @@ GET http://localhost:3000/posts
 
 ###
 
-GET http://localhost:3000/posts?owner=Mevorah
+GET http://localhost:3000/posts?sender=Mevorah
 
 ###
 
@@ -17,7 +17,7 @@ POST http://localhost:3000/posts
 Content-Type: application/json
 
 {
-    "owner": "Mevorah",
+    "sender": "Mevorah",
     "title": "Post 1",
     "content": "HEY!!"
 }


### PR DESCRIPTION
The feature was already done by @mevo0108 at #8 

The `Post.owner` property was renamed to `Post.sender` to match the Assingment's Specification Document.

Closes #4 
